### PR TITLE
Add flag to ignore pip version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ custom:
     globalIncludes:
       - ./common_files
     cleanup: true
+    ignorePipVersionCheck: true
 
 functions:
   function1:
@@ -121,15 +122,16 @@ functions:
 
 The plugin configurations are simple:
 
-| Configuration      | Description                                                                                                                                                                                                        | Optional?                                                  |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
-| buildDir           | Path to a build directory relative to project root, e.g. build                                                                                                                                                     | No                                                         |
-| requirementsFile   | The name of the requirements file used for function-level requirements. All function-level requirements files must use the name specified here.                                                                    | Yes. Defaults to `requirements.txt`                        |
-| globalRequirements | A list of paths to files containing service-level pip requirements.                                                                                                                                                | Yes                                                        |
-| globalIncludes     | A list of paths to folders containing service-level code files (i.e. code common to all functions). Only the folders contents will be packaged, not the folder itself. Paths to files are not currently supported. | Yes                                                        |
-| useDocker          | Boolean indicating whether to package pip dependencies using Docker. Set this to true if your project uses platform-specific compiled libraries like numpy. Requires a [Docker installation](https://www.docker.com/get-docker).                        | Yes. Defaults to `false`                                   |
-| dockerImage        | The Docker image to use to compile functions if `useDocker` is set to `true`. Must be specified as `repository:tag`. If the image doesn't exist on the system, it will be downloaded. The initial download may take some time.                            | Yes. Defaults to `lambci/lambda:build-${provider.runtime}` |
-| containerName      | The desired name for the Docker container.                                                                                                                                                                         | Yes. Defaults to `serverless-package-python-functions`     |
+| Configuration         | Description                                                                                                                                                                                                                      | Optional?                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| buildDir              | Path to a build directory relative to project root, e.g. build                                                                                                                                                                   | No                                                         |
+| requirementsFile      | The name of the requirements file used for function-level requirements. All function-level requirements files must use the name specified here.                                                                                  | Yes. Defaults to `requirements.txt`                        |
+| globalRequirements    | A list of paths to files containing service-level pip requirements.                                                                                                                                                              | Yes                                                        |
+| globalIncludes        | A list of paths to folders containing service-level code files (i.e. code common to all functions). Only the folders contents will be packaged, not the folder itself. Paths to files are not currently supported.               | Yes                                                        |
+| useDocker             | Boolean indicating whether to package pip dependencies using Docker. Set this to true if your project uses platform-specific compiled libraries like numpy. Requires a [Docker installation](https://www.docker.com/get-docker). | Yes. Defaults to `false`                                   |
+| dockerImage           | The Docker image to use to compile functions if `useDocker` is set to `true`. Must be specified as `repository:tag`. If the image doesn't exist on the system, it will be downloaded. The initial download may take some time.   | Yes. Defaults to `lambci/lambda:build-${provider.runtime}` |
+| containerName         | The desired name for the Docker container.                                                                                                                                                                                       | Yes. Defaults to `serverless-package-python-functions`     |
+| ignorePipVersionCheck | Add `--disable-pip-version-check` flag when installing pip package.                                                                                                                                                              | Yes. Defaults to `false`                                   |
 
 At the function level, you:
 - Specify `name` to give your function a name. The plugin uses the function's name as the name of the zip artifact

--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ class PkgPyFuncs {
     const requirePackages = target.requirePackages;
 
     // Create package directory and package files
+    Fse.removeSync(buildPath)
     Fse.ensureDirSync(buildPath)
 
     // Write require package to <function folder>/requirements.txt

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class PkgPyFuncs {
     this.dockerImage = config.dockerImage || `lambci/lambda:build-${this.serverless.service.provider.runtime}`
     this.containerName = config.containerName || 'serverless-package-python-functions'
     this.dockerServicePath = '/var/task'
+    this.ignorePipVersionCheck = config.ignorePipVersionCheck || false;
   }
 
   clean(){
@@ -85,6 +86,9 @@ class PkgPyFuncs {
     }
 
     args = [...args, upath.normalize(requirementsPath)]
+    if (this.ignorePipVersionCheck) {
+      args.push('--disable-pip-version-check')
+    }
     return this.runProcess(cmd, args)
   }
 


### PR DESCRIPTION
Hi @leekad 

Sometimes pip upgrades many times.
If we want to avoid stopping during install process, I added flag `ignorePipVersionCheck`.

If this flag is true, it will append `--disable-pip-version-check` option to `pip install` command.